### PR TITLE
fix: make template buildable with latest libraries

### DIFF
--- a/.github/workflows/generate-check.yaml
+++ b/.github/workflows/generate-check.yaml
@@ -1,0 +1,49 @@
+name: Cargo Generate CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            libdbus-1-dev \
+            libssl-dev \
+            libxkbcommon-dev
+          cargo install cargo-generate
+
+      - name: Prepare custom folder
+        run: mkdir ${{ github.workspace }}/../ci-test
+
+      - name: Run cargo generate in custom folder
+        run: |
+          cargo generate \
+            --path ${{ github.workspace }} \
+            --name example-applet \
+            --define appid="com.github.pop-os.cosmic-app-template"\
+            --define description="example applet"\
+            --define license="MIT"\
+            --define repository-url="https://github.com/pop-os/cosmic-app-template"
+        working-directory: ${{ github.workspace }}/../ci-test
+
+      - name: Run cargo check
+        working-directory: ${{ github.workspace }}/../ci-test/example-applet
+        run: cargo check
+
+      - name: Run cargo clippy
+        working-directory: ${{ github.workspace }}/../ci-test/example-applet
+        run: cargo clippy --all-features

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,8 +3,9 @@
 use crate::config::Config;
 use crate::fl;
 use cosmic::cosmic_config::{self, CosmicConfigEntry};
+use cosmic::iced::futures::channel::mpsc::Sender;
+use cosmic::iced::platform_specific::shell::commands::popup::{destroy_popup, get_popup};
 use cosmic::iced::{window::Id, Limits, Subscription};
-use cosmic::iced_winit::commands::popup::{destroy_popup, get_popup};
 use cosmic::prelude::*;
 use cosmic::widget;
 use futures_util::SinkExt;
@@ -124,14 +125,13 @@ impl cosmic::Application for AppModel {
 
         Subscription::batch(vec![
             // Create a subscription which emits updates through a channel.
-            Subscription::run_with_id(
-                std::any::TypeId::of::<MySubscription>(),
-                cosmic::iced::stream::channel(4, move |mut channel| async move {
+            Subscription::run_with(std::any::TypeId::of::<MySubscription>(), |_| {
+                cosmic::iced::stream::channel(4, move |mut channel: Sender<Message>| async move {
                     _ = channel.send(Message::SubscriptionChannel).await;
 
                     futures_util::future::pending().await
-                }),
-            ),
+                })
+            }),
             // Watch for application configuration changes.
             self.core()
                 .watch_config::<Config>(Self::APP_ID)
@@ -178,7 +178,7 @@ impl cosmic::Application for AppModel {
                         .min_height(200.0)
                         .max_height(1080.0);
                     get_popup(popup_settings)
-                }
+                };
             }
             Message::PopupClosed(id) => {
                 if self.popup.as_ref() == Some(&id) {
@@ -189,7 +189,7 @@ impl cosmic::Application for AppModel {
         Task::none()
     }
 
-    fn style(&self) -> Option<cosmic::iced_runtime::Appearance> {
+    fn style(&self) -> Option<cosmic::iced::theme::Style> {
         Some(cosmic::applet::style())
     }
 }


### PR DESCRIPTION
Upon using the template I noticed that it is currently not building.
Probably due to updated libraries.

Fixed the errors in the template and added some basic CICD to verify that the template is currently buildable.
Tested the CICD [here](https://github.com/hammerlink/cosmic-applet-template/pull/1).
